### PR TITLE
[ES-44] Add issue templates

### DIFF
--- a/ISSUE_TEMPLATE/1-bug-report.md
+++ b/ISSUE_TEMPLATE/1-bug-report.md
@@ -1,0 +1,34 @@
+---
+name: "🐛 Bug report"
+about: "Report a bug with this project"
+title:
+labels: "bug"
+assignees:
+---
+
+## Expected Behavior
+
+Describe what should happen.
+
+## Actual Behavior
+
+Describe what actually happens.
+
+## Step-by-step reproduction instructions
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+
+## Screenshots, screen recordings, code snippets
+
+If possible, please upload a screenshot or screen recording which demonstrates the bug.
+
+## System Information
+
+- Device: <!--  e.g. iPhone 12 -->
+- Operating System: <!-- e.g. iOS 16.6 -->
+- Browser: <!-- e.g. Chrome 118 -->
+<!-- Or paste a link from https://www.whatsmybrowser.org -->
+- WordPress version: <!-- e.g. "5.8.0". Find this in Tools → Site Health → Info → WordPress -->
+- PHP version: <!-- e.g. "8.2". Find this in Tools → Site Health → Info → Server >

--- a/ISSUE_TEMPLATE/1-bug-report.md
+++ b/ISSUE_TEMPLATE/1-bug-report.md
@@ -31,4 +31,4 @@ If possible, please upload a screenshot or screen recording which demonstrates t
 - Browser: <!-- e.g. Chrome 118 -->
 <!-- Or paste a link from https://www.whatsmybrowser.org -->
 - WordPress version: <!-- e.g. "5.8.0". Find this in Tools → Site Health → Info → WordPress -->
-- PHP version: <!-- e.g. "8.2". Find this in Tools → Site Health → Info → Server >
+- PHP version: <!-- e.g. "8.2". Find this in Tools → Site Health → Info → Server -->

--- a/ISSUE_TEMPLATE/2-feature-request.md
+++ b/ISSUE_TEMPLATE/2-feature-request.md
@@ -1,0 +1,11 @@
+---
+name: "🚀 Feature Request"
+about: "Propose an idea for a feature or an enhancement"
+title:
+labels: "enhancement"
+assignees:
+---
+
+## What problem does this address?
+
+## What is your proposed solution?


### PR DESCRIPTION
## Description

This PR adds some issue templates to this repo, so that all projects have some basic temlpates as a starting point.

Related [ES-44](https://b5ecom.atlassian.net/browse/ES-44).

I'm including two templates here:
1. Bug report
2. Feature request

Would appreciate any input regarding changes/improvements but also would like to treat these as a starting point, which can be updated and added to later once we have started to use them. I've avoided using YAML or getting too prescriptive at this stage for that reason.

[ES-44]: https://b5ecom.atlassian.net/browse/ES-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ