### PR TITLE
Fix typos in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -6,11 +6,11 @@ labels: "bug"
 assignees:
 ---
 
-## Expected Behavior
+## Expected Behaviour
 
 Describe what should happen.
 
-## Actual Behavior
+## Actual Behaviour
 
 Describe what actually happens.
 


### PR DESCRIPTION
## Description
The word `behaviour` is spelt incorrectly in the bug report template

## Change Log
- Fix typos in bug report template
