### PR TITLE
Add AI disclosure notes to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -28,6 +28,18 @@ Fixes #123 and [JIRA-0011](https://bigbite.atlassian.net/browse/JIRA-0011) - We'
 
 <!--- Please include a video demonstrating how to use new features. This may include setup. Nothing has to be perfect. --->
 
+### AI Usage (if applicable)
+
+<!---
+If you used AI for any part of this pull request, please explain below.
+This is required as part of our company policy and will also help the code reviewer understand
+which areas may require more detailed review
+
+Example:
+- I have GitHub Copilot set up to auto-complete in my IDE.
+- I asked Copilot to help optimise WP Query when fetching posts
+--->
+
 ## Checklist:
 
 <!--- Have you performed all the below tasks? Put an `x` in all the boxes that apply: -->
@@ -38,3 +50,5 @@ Fixes #123 and [JIRA-0011](https://bigbite.atlassian.net/browse/JIRA-0011) - We'
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] Any dependent changes have been merged and published in downstream modules
+- [ ] I have disclosed all areas where AI assistance was used when creating this pull request, if applicable
+- [ ] AI code suggestions were reviewed and modified to match our coding standards

--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -51,4 +51,4 @@ Example:
 - [ ] My changes generate no new warnings
 - [ ] Any dependent changes have been merged and published in downstream modules
 - [ ] I have disclosed all areas where AI assistance was used when creating this pull request, if applicable
-- [ ] AI code suggestions were reviewed and modified to match our coding standards
+- [ ] AI code suggestions have been manually reviewed and I understand how they work


### PR DESCRIPTION
## Description

Adds additional sections to our default PR template to promote self-disclosure of AI usage.

We're not trying to discourage AI usage here, rather encourage openness and transparency around where and how it has been used by pull request authors.

This will be beneficial to the whole pull request / review process, since a reviewer can focus in on areas where AI was leaned on due to the author being unsure, and conversely a reviewer can tailor how they review code with full knowledge of which pieces might have been auto-generated.

For example, if a section of code is perhaps taking the wrong direction, but only took a couple minutes to implement as an AI suggestion, a reviewer might be more inclined to nudge an author towards binning it and trying another approach, rather than providing in-depth feedback.

We also want to reinforce the point that whilst you can use AI to generate code, you are ultimately responsible for it's output so should take time to edit, adjust, format and understand it prior to creating a pull request.

This is open to feedback and suggestions, and should be adjusted as the landscape and our usage of AI evolves.